### PR TITLE
Fix deploy script to include an extra package required for wxPython

### DIFF
--- a/deploy_slave.sh
+++ b/deploy_slave.sh
@@ -91,6 +91,9 @@ cp piwheels-slave.service /etc/systemd/system/
 systemctl enable piwheels-slave.service
 pip3 install .
 
+# temporary workaround for wxPython requiring pathlib2 to build
+pip3 install pathlib2
+
 if ! grep swapfile /etc/rc.local >/dev/null; then
     dd if=/dev/zero of=/swapfile bs=1M count=1024
     chmod 0600 /swapfile


### PR DESCRIPTION
Appears to be something that should be temporary if done at all; see
https://github.com/wxWidgets/Phoenix/pull/1241
https://github.com/wxWidgets/Phoenix/issues/1251

This would fix piwheels/packages#1.