### PR TITLE
Add missing docstrings in states

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -7,6 +7,11 @@ code. It is probably not terribly useful for reading through, but may be useful
 as a searchable reference.
 
 
+.. contents::
+    :depth: 1
+    :local:
+
+
 piwheels.master
 ===============
 

--- a/piwheels/states.py
+++ b/piwheels/states.py
@@ -760,20 +760,17 @@ class DownloadState(namedtuple('DownloadState', (
     file, including its :attr:`filename`, the user's :attr:`host` IP, access
     :attr:`timestamp` and information about the operating system and installer.
 
-    :type filename: str
-    :param filename:
+    :param str filename:
         The filename of the downloaded wheel file.
 
-    :type host: str
     :param host:
-        The IP address of the user.
+        The hostname or IP address of the user.
 
-    :type timestamp: :class:`datetime.datetime`
-    :param timestamp:
+    :param datetime.datetime timestamp:
         The timestamp at which the file was downloaded.
 
     :type arch: str or None
-    :param arch:
+    :param str or None arch:
         The architecture of the user's computer system (usually armv6 or
         armv7).
 
@@ -843,16 +840,13 @@ class SearchState(namedtuple('SearchState', (
     including the :attr:`package` name, user's :attr:`host` IP, access
     :attr:`timestamp` and information about the operating system and installer.
 
-    :type package: str
-    :param package:
+    :param str package:
         The name of the package searched for.
 
-    :type host: str
-    :param host:
-        The IP address of the user.
+    :param str host:
+        The hostname or IP address of the user.
 
-    :type timestamp: :class:`datetime.datetime`
-    :param timestamp:
+    :param datetime.datetime timestamp:
         The timestamp at which the search occurred.
 
     :type arch: str or None
@@ -916,13 +910,11 @@ class ProjectState(namedtuple('ProjectState', (
     including the :attr:`page` name, the user's :attr:`host` IP, access
     :attr:`timestamp` and the user's :attr:`user_agent`.
 
-    :type package: str
-    :param package:
+    :param str package:
         The name of the package searched for.
 
-    :type host: str
-    :param host:
-        The IP address of the user.
+    :param str host:
+        The hostname or IP address of the user.
 
     :type timestamp: :class:`datetime.datetime`
     :param timestamp:
@@ -953,19 +945,15 @@ class JSONState(namedtuple('JSONState', (
     download, including the :attr:`page` name, the user's :attr:`host` IP,
     access :attr:`timestamp` and the user's :attr:`user_agent`.
 
-    :type package: str
-    :param package:
+    :param str package:
         The name of the package whose JSON file was accessed.
 
-    :type host: str
-    :param host:
-        The IP address of the user.
+    :param str host:
+        The hostname or IP address of the user.
 
-    :type timestamp: :class:`datetime.datetime`
-    :param timestamp:
+    :param datetime.datetime timestamp:
         The timestamp at which the page was accessed.
 
-    :type host: str
     :param str user_agent:
         The user agent of the request.
     """
@@ -990,19 +978,15 @@ class PageState(namedtuple('PageState', (
     including the :attr:`page` name, the user's :attr:`host` IP, access
     :attr:`timestamp` and the user's :attr:`user_agent`.
 
-    :type page: str
-    :param page:
+    :param str page:
         The name of the page accessed.
 
-    :type host: str
-    :param host:
+    :param str host:
         The IP address of the user.
 
-    :type timestamp: :class:`datetime.datetime`
-    :param timestamp:
+    :param datetime.datetime timestamp:
         The timestamp at which the page was accessed.
 
-    :type host: str
     :param str user_agent:
         The user agent of the page request.
     """

--- a/piwheels/states.py
+++ b/piwheels/states.py
@@ -616,8 +616,8 @@ class TransferState:
     :param str slave_id:
         The ID number of the slave which built the file.
 
-    :param str file_state:
-        XXX
+    :param FileState file_state:
+        The details of the file to be transferred (filename, size, hash, etc.)
     """
 
     chunk_size = 65536

--- a/piwheels/states.py
+++ b/piwheels/states.py
@@ -427,6 +427,24 @@ class SlaveState:
     :attr:`build`) and :class:`TransferState` (accessible from
     :attr:`transfer`). The class also tracks the time a request was last seen
     from the build slave, and includes a :meth:`kill` method.
+
+    :param str address:
+        The slave's XXX address.
+
+    :param str timeout:
+        XXX
+
+    :param str native_py_version:
+        The slave's native Python version.
+
+    :param str native_abi:
+        The slave's native Python ABI.
+
+    :param str native_platform:
+        The slave's native platform.
+
+    :param str label:
+        A label representing the slave.
     """
     counter = 0
     status_queue = None
@@ -586,6 +604,12 @@ class TransferState:
     methods to write a recevied :meth:`chunk`, and to determine the next chunk
     to :meth:`fetch`, as well as a property to determine when the transfer is
     :attr:`done`.
+
+    :param str slave_id:
+        The ID number of the slave which built the file.
+
+    :param str file_state:
+        XXX
     """
 
     chunk_size = 65536
@@ -723,6 +747,64 @@ class DownloadState(namedtuple('DownloadState', (
     'installer_version',
     'setuptools_version',
 ))):
+    """
+    Represents the state of the log entry for a download of a package wheel
+    file, including its :attr:`filename`, the user's :attr:`host` IP, access
+    :attr:`timestamp` and information about the operating system and installer.
+
+    :type filename: str
+    :param filename:
+        The filename of the downloaded wheel file.
+
+    :type host: str
+    :param host:
+        The IP address of the user.
+
+    :type timestamp: :class:`datetime.datetime`
+    :param timestamp:
+        The timestamp at which the file was downloaded.
+
+    :type arch: str or None
+    :param arch:
+        The architecture of the user's computer system (usually armv6 or
+        armv7).
+
+    :type distro_name: str or None
+    :param distro_name:
+        The user's operating system distribution name (e.g. Raspbian).
+
+    :type distro_version: str or None
+    :param distro_version:
+        The version of the user's operating system distribution.
+
+    :type os_name: str or None
+    :param os_name:
+        The name of the user's operating system (e.g. Linux).
+
+    :type os_version: str or None
+    :param os_version:
+        The version of the user's operating system (e.g. Linux kernel version).
+
+    :type py_name: str or None
+    :param py_name:
+        The Python implementation used (e.g. CPython).
+
+    :type py_version: str or None
+    :param py_version:
+        The Python version used (e.g. 3.7.3).
+
+    :type installer_name: str or None
+    :param installer_name:
+        The name of the tool used to install the file (e.g. pip).
+
+    :type installer_version: str or None
+    :param installer_version:
+        The version of the tool (e.g. pip) used to install the file.
+
+    :type setuptools_version: str or None
+    :param setuptools_version:
+        The version of setuptools used.
+    """
     __slots__ = ()
 
     def as_message(self):
@@ -748,6 +830,63 @@ class SearchState(namedtuple('SearchState', (
     'installer_version',
     'setuptools_version',
 ))):
+    """
+    Represents the state of the log entry for an instance of a package search,
+    including the :attr:`package` name, user's :attr:`host` IP, access
+    :attr:`timestamp` and information about the operating system and installer.
+
+    :type package: str
+    :param package:
+        The name of the package searched for.
+
+    :type host: str
+    :param host:
+        The IP address of the user.
+
+    :type timestamp: :class:`datetime.datetime`
+    :param timestamp:
+        The timestamp at which the search occurred.
+
+    :type arch: str or None
+    :param arch:
+        The architecture of the user's computer system (usually armv6 or armv7).
+
+    :type distro_name: str or None
+    :param distro_name:
+        The user's operating system distribution name (e.g. Raspbian).
+
+    :type distro_version: str or None
+    :param distro_version:
+        The version of the user's operating system distribution.
+
+    :type os_name: str or None
+    :param os_name:
+        The name of the user's operating system (e.g. Linux).
+
+    :type os_version: str or None
+    :param os_version:
+        The version of the user's operating system (e.g. Linux kernel version).
+
+    :type py_name: str or None
+    :param py_name:
+        The Python implementation used (e.g. CPython).
+
+    :type py_version: str or None
+    :param py_version:
+        The Python version used (e.g. 3.7.3).
+
+    :type installer_name: str or None
+    :param installer_name:
+        The name of the tool used (e.g. pip).
+
+    :type installer_version: str or None
+    :param installer_version:
+        The version of the tool (e.g. pip) used.
+
+    :type setuptools_version: str or None
+    :param setuptools_version:
+        The version of setuptools used.
+    """
     __slots__ = ()
 
     def as_message(self):
@@ -764,6 +903,27 @@ class ProjectState(namedtuple('ProjectState', (
     'timestamp',
     'user_agent',
 ))):
+    """
+    Represents the state of the log entry for an instance of project page hit,
+    including the :attr:`page` name, the user's :attr:`host` IP, access
+    :attr:`timestamp` and the user's :attr:`user_agent`.
+
+    :type package: str
+    :param package:
+        The name of the package searched for.
+
+    :type host: str
+    :param host:
+        The IP address of the user.
+
+    :type timestamp: :class:`datetime.datetime`
+    :param timestamp:
+        The timestamp at which the page was accessed.
+
+    :type host: str
+    :param str user_agent:
+        The user agent of the page request.
+    """
     __slots__ = ()
 
     def as_message(self):
@@ -780,6 +940,27 @@ class JSONState(namedtuple('JSONState', (
     'timestamp',
     'user_agent',
 ))):
+    """
+    Represents the state of the log entry for an instance of project JSON
+    download, including the :attr:`page` name, the user's :attr:`host` IP,
+    access :attr:`timestamp` and the user's :attr:`user_agent`.
+
+    :type package: str
+    :param package:
+        The name of the package whose JSON file was accessed.
+
+    :type host: str
+    :param host:
+        The IP address of the user.
+
+    :type timestamp: :class:`datetime.datetime`
+    :param timestamp:
+        The timestamp at which the page was accessed.
+
+    :type host: str
+    :param str user_agent:
+        The user agent of the request.
+    """
     __slots__ = ()
 
     def as_message(self):
@@ -796,6 +977,27 @@ class PageState(namedtuple('PageState', (
     'timestamp',
     'user_agent',
 ))):
+    """
+    Represents the state of the log entry for an instance of web page hit,
+    including the :attr:`page` name, the user's :attr:`host` IP, access
+    :attr:`timestamp` and the user's :attr:`user_agent`.
+
+    :type page: str
+    :param page:
+        The name of the page accessed.
+
+    :type host: str
+    :param host:
+        The IP address of the user.
+
+    :type timestamp: :class:`datetime.datetime`
+    :param timestamp:
+        The timestamp at which the page was accessed.
+
+    :type host: str
+    :param str user_agent:
+        The user agent of the page request.
+    """
     __slots__ = ()
 
     def as_message(self):

--- a/piwheels/states.py
+++ b/piwheels/states.py
@@ -421,18 +421,26 @@ class BuildState:
 
 class SlaveState:
     """
-    Tracks the state of a build slave. The master updates this state which each
+    Tracks the state of a build slave. The master updates this state with each
     request and reply sent to and received from the slave, and this class in
     turn manages the associated :class:`BuildState` (accessible from
     :attr:`build`) and :class:`TransferState` (accessible from
     :attr:`transfer`). The class also tracks the time a request was last seen
     from the build slave, and includes a :meth:`kill` method.
 
-    :param str address:
-        The slave's XXX address.
+    :param bytes address:
+        The slave's ephemeral 0MQ address.
 
-    :param str timeout:
-        XXX
+        .. note::
+
+            This is *not* the slave's IP address; it's a unique identifier
+            generated on connection to the master's ROUTER socket. It will be
+            different each time the slave re-connects (due to timeout, reboot,
+            etc).
+
+    :param int timeout:
+        The number of seconds after which any build will be considered to have
+        timed out (and the slave will be assumed crashed).
 
     :param str native_py_version:
         The slave's native Python version.


### PR DESCRIPTION
@waveform80 I've filled out docstrings/params in my new state classes and added as much as I could for those missing from preexisting state classes. There are a couple of params I didn't feel confident in describing:

```
    :param str address:
        The slave's XXX address.

    :param str timeout:
        XXX
```

so can you complete those? You should give a cursory glance over the changes just in case.