### PR TITLE
Add rust compiler to deploy script

### DIFF
--- a/deploy_slave.sh
+++ b/deploy_slave.sh
@@ -73,6 +73,10 @@ apt -y install vim ssh-import-id tree byobu htop pkg-config cmake time pandoc \
 
 apt purge python3-cryptography -y
 
+# Install rust compiler
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o /tmp/rustup.sh
+sh /tmp/rustup.sh -y
+
 pip3 install setuptools --upgrade
 pip3 install $PIP --upgrade
 hash -r


### PR DESCRIPTION
This commit adds the latest version of the rust compiler to the deploy
script. This will enable building python extensions built in rust
using PyO3 [1], rust-cpython [2], or other python rust bindings. This
includes packages such as retworkx[3][4], orjson[5], pyawabi[6], and
jsonlogic-rs[7]. There is a buster package for the rust compiler
available [8] but the version packaged in buster is too old for use with
packages built using the PyO3 library (it requires rustc>=1.39), which is
used by many of the extensions written in rust to interface to Python's C
API. So instead this relies on the official rust language builds, using
the rust installer rustup to download and install the compiler. This will
enable workers to compile rust code so wheels of these packages can be
distributed. The binaries compiled by rust will not have any dependency on
having rust installed on end user systems, the only run time dependencies
are standard system libs (libc, etc) and python.

[1] https://github.com/PyO3/pyo3
[2] https://github.com/dgrunwald/rust-cpython
[3] https://pypi.org/project/retworkx/
[4] https://github.com/piwheels/packages/issues/99
[5] https://pypi.org/project/orjson/
[6] https://pypi.org/project/pyawabi/
[7] https://pypi.org/project/jsonlogic-rs/
[8] https://packages.debian.org/buster/rustc