### PR TITLE
Add cargo debian package to enable rust builds

### DIFF
--- a/deploy_slave.sh
+++ b/deploy_slave.sh
@@ -55,7 +55,8 @@ apt -y install vim ssh-import-id tree byobu htop pkg-config cmake time pandoc \
     xfonts-cyrillic fluid-soundfont-gm libsystemd-dev libusb-1.0-0-dev \
     libudev-dev libopus-dev libvpx-dev libc-bin libavdevice-dev \
     libadios-dev libavfilter-dev libavutil-dev libcec-dev lsb-release \
-    $PYBIND libsnappy-dev libpcap0.8-dev swig $LIBZMQ portaudio19-dev
+    $PYBIND libsnappy-dev libpcap0.8-dev swig $LIBZMQ portaudio19-dev \
+    cargo
 
 apt purge python3-cryptography -y
 


### PR DESCRIPTION
The buster rustc and cargo packages backported version 1.41.1 in September 2020 [1][2][3]
this version is new enough to satisfy the minimum rust versions supported by PyO3 Rust
Python bindings [4]. This commit adds cargo to the package list in the deploy script to
enable piwheels to build precompiled binaries of Python  extensions written in Rust (such
as orjson[5], retworkx[6], and many others).

[1] https://metadata.ftp-master.debian.org/changelogs//main/r/rustc/rustc_1.41.1+dfsg1-1~deb10u1_changelog
[2] https://packages.debian.org/buster/rustc
[3] https://packages.debian.org/buster/cargo
[4] https://github.com/PyO3/pyo3
[5] https://pypi.org/project/orjson/ 
[6] https://pypi.org/project/retworkx/