### PR TITLE
Add --no-binary flag to pip command

### DIFF
--- a/piwheels/slave/builder.py
+++ b/piwheels/slave/builder.py
@@ -431,6 +431,7 @@ class Builder(Thread):
             '--log={}'.format(log_file.name),
             '--no-deps',                    # don't build dependencies
             '--no-cache-dir',               # disable the cache directory
+            '--no-binary=:all:',            # never get binary wheels
             '--exists-action=w',            # wipe existing paths
             '--disable-pip-version-check',  # don't check for new pip
             '{}=={}'.format(self.package, self.version),


### PR DESCRIPTION
- Closes #275﻿

This adds in a line which was removed in 7a66bab5545cd7e8af0c4583dea27d5b12696d30 - although I can't think why it was removed in the first place (it's a large diff and this section of code was moved but this particular flag didn't seem to make it across).