### PR TITLE
add ninja-build for jarowinkler

### DIFF
--- a/deploy_slave.sh
+++ b/deploy_slave.sh
@@ -64,7 +64,8 @@ apt -y install vim ssh-import-id tree byobu htop pkg-config cmake time pandoc \
     libsnappy-dev libpcap0.8-dev swig libzmq5 portaudio19-dev libqpdf-dev \
     coinor-libipopt-dev libsrtp2-dev default-libmysqlclient-dev cargo golang \
     libgeos-dev $LIBGLES $LIBXLST $SOUNDFONT $POSTGRES_SERVER_DEV $TURBOGEARS \
-    $PYTHON2_PACKAGES $QMAKE libgphoto2-dev libsqlite3-dev libsqlcipher-dev
+    $PYTHON2_PACKAGES $QMAKE libgphoto2-dev libsqlite3-dev libsqlcipher-dev \
+    ninja-build
 
 apt purge python3-cryptography -y
 


### PR DESCRIPTION
I excluded the ninja+cmake dependency for jarowinkler on arm platforms, since they often fail to build from source. For this reason those packages need to be available on the host. Cmake is already available on the build slave, but ninja appears to be missing so far.