### PR TITLE
add environment variable to specify build

### DIFF
--- a/piwheels/slave/builder.py
+++ b/piwheels/slave/builder.py
@@ -437,7 +437,7 @@ class Builder(Thread):
         env['GIT_ALLOW_PROTOCOL'] = 'file'
         
         # allow projects to detect they are built in piwheels
-        env['PIWHEEL_BUILD'] = "1"
+        env['PIWHEELS_BUILD'] = "1"
         return env
 
     def build_command(self, log_file):

--- a/piwheels/slave/builder.py
+++ b/piwheels/slave/builder.py
@@ -435,6 +435,9 @@ class Builder(Thread):
         # disturbing minority of packages try to run git clone during their
         # setup.py)
         env['GIT_ALLOW_PROTOCOL'] = 'file'
+        
+        # allow projects to detect they are built in piwheels
+        env['PIWHEEL_BUILD'] = "1"
         return env
 
     def build_command(self, log_file):


### PR DESCRIPTION
This is an attempt at implementing #319. I am not sure what name you prefer for the environment variable. Some examples are:
- `CI` -> set by many ci systems like e.g. github actions / gitlab ci
- `CIBUILDWHEEL` -> set by cibuildwheel when building wheels
- `CONDA_BUILD` -> set by conda forge when building the binaries