### PR TITLE
Install rustup as piwheels user

### DIFF
--- a/deploy_slave.sh
+++ b/deploy_slave.sh
@@ -78,7 +78,7 @@ getent group piwheels || groupadd piwheels
 getent passwd piwheels || useradd -g piwheels -m -s /bin/bash piwheels
 passwd -d piwheels
 
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sudo -u piwheels sh -s -- -y
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | runuser -- - piwheels -s -- -y
 
 if [ -d piwheels ]; then
     cd piwheels

--- a/deploy_slave.sh
+++ b/deploy_slave.sh
@@ -42,7 +42,7 @@ fi
 
 apt update
 apt -y upgrade
-apt -y install vim wget curl ssh-import-id tree byobu htop pkg-config cmake time pandoc \
+apt -y install sudo vim wget curl ssh-import-id tree byobu htop pkg-config cmake time pandoc \
     gfortran ipython3 git qt5-qmake python3-dev python3-pip python3-apt \
     zlib1g-dev libpq-dev libffi-dev libxml2-dev libhdf5-dev libldap2-dev \
     libjpeg-dev libbluetooth-dev libusb-dev libhidapi-dev libfreetype6-dev \
@@ -78,8 +78,7 @@ getent group piwheels || groupadd piwheels
 getent passwd piwheels || useradd -g piwheels -m -s /bin/bash piwheels
 passwd -d piwheels
 
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-cat .cargo/env >> /home/piwheels/.bashrc
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sudo -u pisheels sh -s -- -y
 
 if [ -d piwheels ]; then
     cd piwheels

--- a/deploy_slave.sh
+++ b/deploy_slave.sh
@@ -79,10 +79,14 @@ getent passwd piwheels || useradd -g piwheels -m -s /bin/bash piwheels
 passwd -d piwheels
 
 # Enforce 32-bit kernel as the 64-bit kernel is used by default (also on RPi OS 32-bit) since RPi Linux 6.1
-sed -i '/^[[:blank:]]*arm_64bit=/d' /boot/config.txt # remove arm_64bit first
-sed -i '1iarm_64bit=0' /boot/config.txt # add arm_64bit to top of file to assure it is effective on all RPi models
+if [ -f /boot/config.txt ]; then
+    sed -i '/^[[:blank:]]*arm_64bit=/d' /boot/config.txt # remove setting first
+    sed -i '1iarm_64bit=0' /boot/config.txt # readd setting to top of file to assure it is effective on all RPi models
+else
+    echo 'arm_64bit=0' > /boot/config.txt
+fi
 
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | runuser -- - piwheels -s -- -y --profile minimal --default-host arm-unknown-linux-gnueabihf
+curl -sSf 'https://sh.rustup.rs' | runuser -- - piwheels -s -- -y --profile minimal --default-host arm-unknown-linux-gnueabihf
 
 if [ -d piwheels ]; then
     cd piwheels

--- a/deploy_slave.sh
+++ b/deploy_slave.sh
@@ -78,7 +78,7 @@ getent group piwheels || groupadd piwheels
 getent passwd piwheels || useradd -g piwheels -m -s /bin/bash piwheels
 passwd -d piwheels
 
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | runuser -- - piwheels -s -- -y --profile minimal
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | runuser -- - piwheels -s -- -y --profile minimal --default-host arm-unknown-linux-gnueabihf
 
 if [ -d piwheels ]; then
     cd piwheels

--- a/deploy_slave.sh
+++ b/deploy_slave.sh
@@ -78,7 +78,7 @@ getent group piwheels || groupadd piwheels
 getent passwd piwheels || useradd -g piwheels -m -s /bin/bash piwheels
 passwd -d piwheels
 
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | runuser -- - piwheels -s -- -y
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | runuser -- - piwheels -s -- -y --profile minimal
 
 if [ -d piwheels ]; then
     cd piwheels

--- a/deploy_slave.sh
+++ b/deploy_slave.sh
@@ -42,7 +42,7 @@ fi
 
 apt update
 apt -y upgrade
-apt -y install sudo vim wget curl ssh-import-id tree byobu htop pkg-config cmake time pandoc \
+apt -y install vim wget curl ssh-import-id tree byobu htop pkg-config cmake time pandoc \
     gfortran ipython3 git qt5-qmake python3-dev python3-pip python3-apt \
     zlib1g-dev libpq-dev libffi-dev libxml2-dev libhdf5-dev libldap2-dev \
     libjpeg-dev libbluetooth-dev libusb-dev libhidapi-dev libfreetype6-dev \

--- a/deploy_slave.sh
+++ b/deploy_slave.sh
@@ -78,14 +78,6 @@ getent group piwheels || groupadd piwheels
 getent passwd piwheels || useradd -g piwheels -m -s /bin/bash piwheels
 passwd -d piwheels
 
-# Enforce 32-bit kernel as the 64-bit kernel is used by default (also on RPi OS 32-bit) since RPi Linux 6.1
-if [ -f /boot/config.txt ]; then
-    sed -i '/^[[:blank:]]*arm_64bit=/d' /boot/config.txt # remove setting first
-    sed -i '1iarm_64bit=0' /boot/config.txt # readd setting to top of file to assure it is effective on all RPi models
-else
-    echo 'arm_64bit=0' > /boot/config.txt
-fi
-
 curl -sSf 'https://sh.rustup.rs' | runuser -- - piwheels -s -- -y --profile minimal --default-host arm-unknown-linux-gnueabihf
 
 if [ -d piwheels ]; then

--- a/deploy_slave.sh
+++ b/deploy_slave.sh
@@ -78,6 +78,10 @@ getent group piwheels || groupadd piwheels
 getent passwd piwheels || useradd -g piwheels -m -s /bin/bash piwheels
 passwd -d piwheels
 
+# Enforce 32-bit kernel as the 64-bit kernel is used by default (also on RPi OS 32-bit) since RPi Linux 6.1
+sed -i '/^[[:blank:]]*arm_64bit=/d' /boot/config.txt # remove arm_64bit first
+sed -i '1iarm_64bit=0' /boot/config.txt # add arm_64bit to top of file to assure it is effective on all RPi models
+
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | runuser -- - piwheels -s -- -y --profile minimal --default-host arm-unknown-linux-gnueabihf
 
 if [ -d piwheels ]; then

--- a/deploy_slave.sh
+++ b/deploy_slave.sh
@@ -78,7 +78,7 @@ getent group piwheels || groupadd piwheels
 getent passwd piwheels || useradd -g piwheels -m -s /bin/bash piwheels
 passwd -d piwheels
 
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sudo -u pisheels sh -s -- -y
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sudo -u piwheels sh -s -- -y
 
 if [ -d piwheels ]; then
     cd piwheels

--- a/piwheels/slave/builder.py
+++ b/piwheels/slave/builder.py
@@ -438,6 +438,11 @@ class Builder(Thread):
         
         # allow projects to detect they are built in piwheels
         env['PIWHEELS_BUILD'] = "1"
+
+        # Add Rust compiler to PATH if missing
+        if '.cargo/bin' not in env['PATH']:
+            env['PATH'] = f"{env['HOME']}/.cargo/bin:{env['PATH']}"
+
         return env
 
     def build_command(self, log_file):


### PR DESCRIPTION
#322 doesn't work yet, since rustup is installed by `root` into `/root/.cargo/bin` where `piwheels` has no read or execute access to. This commit changes this so rustup is installed as `piwheels` user into `/home/piwheels/.cargo/bin`.

rustup itself appends `. "$HOME/.cargo/env"` to `/home/piwheels/.bashrc`, so repeating this is redundant. However, `~/.bashrc` is not loaded in non-interactive bash sessions, hence not in scripts and `bash -c` calls. If piwheels builds imply any interactive `piwheels` session, this is not an issue, since `$PATH` is exported and hence survives into scripts, but otherwise
```sh
export PATH="/home/piwheels/.cargo/bin:$PATH"
```
would need to be additionally done at the start of build scripts.