### PR TITLE
Add dependabot config for GitHub Actions and Python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
with weekly update checks

It also needs to be enabled in repository security settings. It will also take care of GitHub Actions versions, so manual PRs like #332 are not needed anymore.

Oh, that was fast, here is the result (on my fork): https://github.com/MichaIng/piwheels/pulls