### PR TITLE
Adds OpenBLAS for SciPy/NumPy

### DIFF
--- a/deploy_slave.sh
+++ b/deploy_slave.sh
@@ -61,7 +61,7 @@ apt -y install vim wget curl ssh-import-id tree byobu htop pkg-config cmake time
     coinor-libipopt-dev libsrtp2-dev default-libmysqlclient-dev golang \
     libgeos-dev $LIBGLES $LIBXLST $SOUNDFONT $POSTGRES_SERVER_DEV $TURBOGEARS \
     $PYTHON2_PACKAGES $QMAKE libgphoto2-dev libsqlite3-dev libsqlcipher-dev \
-    ninja-build $FPRINT libgirepository1.0-dev libfmt-dev
+    ninja-build $FPRINT libgirepository1.0-dev libfmt-dev libopenblas-dev
 
 apt purge python3-cryptography python3-yaml -y
 


### PR DESCRIPTION
This PR adds the OpenBLAS development package, as required for building scipy 1.9+.  See the [docs here](https://docs.scipy.org/doc/scipy/dev/contributor/building.html).

I couldn't find the webpage source to update the install commands to note this change for users.  Including the older and newer instructions would probably be helpful.

Fixes: piwheels/packages/issues/315