### PR TITLE
Mark Buster as inactive and update an example in the FAQ

### DIFF
--- a/piwheels/master/templates/faq.pt
+++ b/piwheels/master/templates/faq.pt
@@ -218,7 +218,7 @@ $ virtualenv -p /usr/bin/python3 testpip</pre>
         <ul>
           <li>Jessie - Python 3.4 (end-of-life)</li>
           <li>Stretch - Python 3.5 (end-of-life)</li>
-          <li>Buster - Python 3.7</li>
+          <li>Buster - Python 3.7 (end-of-life)</li>
           <li>Bullseye - Python 3.9</li>
           <li>Bookworm - Python 3.11</li>
         </ul>
@@ -416,7 +416,7 @@ pip3 wheel <em>&lt;package&gt;</em></pre>
 
         <p>To download the wheels using your PC, you will need to provide
         additional flags to specify the spec of the Pi. For example, Armv7
-        wheels (for a Pi 2/3/4) for Buster (cp37m):</p>
+        wheels (for a Pi 2/3/4) for Bookworm (cp11):</p>
 
         <pre>mkdir wheels
 cd wheels
@@ -424,7 +424,7 @@ python3 -m pip download \
     --extra-index-url https://www.piwheels.org/simple \
     --implementation cp \
     --platform linux_armv7l \
-    --abi cp37m \
+    --abi cp39 \
     --only-binary=:all: \
     <em>&lt;package&gt;</em></pre>
 

--- a/piwheels/master/templates/index.pt
+++ b/piwheels/master/templates/index.pt
@@ -57,7 +57,7 @@ $ rm -rf testpip/</pre>
         <tr><th>Raspberry Pi OS version</th><th>Python version</th><th>Status</th></tr>
         <tr><td>Jessie</td><td>Python 3.4</td><td class="skip" title="Inactive (end of life)"></td></tr>
         <tr><td>Stretch</td><td>Python 3.5</td><td class="skip" title="Inactive (end of life)"></td></tr>
-        <tr><td>Buster</td><td>Python 3.7</td><td class="success" title="Active"></td></tr>
+        <tr><td>Buster</td><td>Python 3.7</td><td class="skip" title="Inactive (end of life)"></td></tr>
         <tr><td>Bullseye</td><td>Python 3.9</td><td class="success" title="Active"></td></tr>
         <tr><td>Bookworm</td><td>Python 3.11</td><td class="success" title="Active"></td></tr>
       </table>


### PR DESCRIPTION
This PR marks Buster as inactive on the homepage and updates an example in the FAQ.

We can also drop support for Python 3.7 from the codebase itself, but we can do this later.