### PR TITLE
PEP-658: Create metadata file

### DIFF
--- a/piwheels/audit/audit_packages.py
+++ b/piwheels/audit/audit_packages.py
@@ -191,7 +191,7 @@ def check_package_index(config, package, db):
             if config.hashes:
                 check_wheel_hash(config, file_path, filehash)
 
-            metadata_file = check_wheel_metadata_file(config, package, filename)
+            metadata_file = check_wheel_metadata_file(config, file_path)
             try:
                 all_files.remove(metadata_file)
             except KeyError:
@@ -262,15 +262,13 @@ def get_package_tag(filename):
     return canonicalize_name(package_tag)
 
 
-def check_wheel_metadata_file(config, package, filename):
-    pkg_dir = config.output_path / 'simple' / package
-    wheel_file = pkg_dir / filename
-    whl_metadata_file = wheel_file.with_suffix('.whl.metadata')
+def check_wheel_metadata_file(config, file_path):
+    whl_metadata_file = file_path.with_suffix('.whl.metadata')
     if not whl_metadata_file.exists():
         if config.create_missing_metadata:
-            create_wheel_metadata_file(wheel_file)
+            create_wheel_metadata_file(file_path)
         else:
-            report_missing(config, 'wheel metadata file', wheel_file)
+            report_missing(config, 'wheel metadata file', file_path)
     return whl_metadata_file
 
 

--- a/piwheels/audit/audit_packages.py
+++ b/piwheels/audit/audit_packages.py
@@ -44,6 +44,7 @@ from .report import report_extra, report_missing, report_broken
 from .. import __version__, terminal, const
 from ..master.db import Database
 from ..format import canonicalize_name
+from ..states import create_wheel_metadata_file
 
 
 def main(args=None):
@@ -105,6 +106,9 @@ number of given packages, or all packages in the index.
     parser.add_argument(
         '--delete-extras', action='store_true',
         help="If specified, the script will delete all extraneous files")
+    parser.add_argument(
+        '--create-missing-metadata', action='store_true',
+        help="If specified, the script will create missing .whl.metadata files")
     parser.add_argument(
         '--archive-dir',
         help="The location of the archive server's mount point")
@@ -187,6 +191,12 @@ def check_package_index(config, package, db):
             if config.hashes:
                 check_wheel_hash(config, file_path, filehash)
 
+            metadata_file = check_wheel_metadata_file(config, package, filename)
+            try:
+                all_files.remove(metadata_file)
+            except KeyError:
+                pass
+
     # all_files now contains only files that are not in the index
     # so we can report them as extraneous, or delete them
     handle_extraneous_files(config, all_files, simple_pkg_dir)
@@ -250,6 +260,18 @@ def handle_extraneous_files(config, extra_files, simple_pkg_dir):
 def get_package_tag(filename):
     package_tag = filename.split("-")[0]
     return canonicalize_name(package_tag)
+
+
+def check_wheel_metadata_file(config, package, filename):
+    pkg_dir = config.output_path / 'simple' / package
+    wheel_file = pkg_dir / filename
+    whl_metadata_file = wheel_file.with_suffix('.whl.metadata')
+    if not whl_metadata_file.exists():
+        if config.create_missing_metadata:
+            create_wheel_metadata_file(wheel_file)
+        else:
+            report_missing(config, 'wheel metadata file', wheel_file)
+    return whl_metadata_file
 
 
 class LinkExtractor(HTMLParser):

--- a/piwheels/master/the_scribe.py
+++ b/piwheels/master/the_scribe.py
@@ -666,6 +666,13 @@ class TheScribe(tasks.PauseableTask):
             except FileNotFoundError:
                 self.logger.error('file not found: %s', file_path)
 
+            metadata_file = file_path.with_suffix('.whl.metadata')
+            try:
+                metadata_file.unlink()
+                self.logger.debug('file deleted: %s', metadata_file)
+            except FileNotFoundError:
+                self.logger.error('file not found: %s', metadata_file)
+
         for dir_path in (pkg_dir, proj_json_dir, proj_dir):
             try:
                 dir_path.rmdir()

--- a/piwheels/master/the_scribe.py
+++ b/piwheels/master/the_scribe.py
@@ -666,12 +666,9 @@ class TheScribe(tasks.PauseableTask):
             except FileNotFoundError:
                 self.logger.error('file not found: %s', file_path)
 
-            metadata_file = file_path.with_suffix('.whl.metadata')
-            try:
-                metadata_file.unlink()
-                self.logger.debug('file deleted: %s', metadata_file)
-            except FileNotFoundError:
-                self.logger.error('file not found: %s', metadata_file)
+            if file_path.suffix == '.whl':
+                metadata_file = file_path.with_suffix('.whl.metadata')
+                metadata_file.unlink(missing_ok=True)
 
         for dir_path in (pkg_dir, proj_json_dir, proj_dir):
             try:

--- a/piwheels/states.py
+++ b/piwheels/states.py
@@ -74,6 +74,7 @@ import tempfile
 from pathlib import Path
 from datetime import datetime, timezone
 from collections import namedtuple, deque
+from zipfile import ZipFile
 
 from .ranges import exclude, intersect
 
@@ -813,8 +814,10 @@ class TransferState:
         # the case of an actual armv6 build being uploaded, it will (rightly)
         # clobber any symlink currently in place
         tmp_file.rename(final_name)
+        whl_metadata_file = create_wheel_metadata_file(final_name)
         if self._file_state.platform_tag == 'linux_armv7l':
             self.create_armv6_symlink(final_name)
+            self.create_armv6_symlink(whl_metadata_file)
         self._file_state.verified()
 
     def create_armv6_symlink(self, armv7_path):
@@ -833,6 +836,27 @@ class TransferState:
 
     def rollback(self):
         Path(self._file.name).unlink()
+
+
+def create_wheel_metadata_file(wheel_file: Path) -> Path:
+    """
+    Extract the METADATA file from a wheel, and create a corresponding
+    .whl.metadata file. Return the path to the new metadata file.
+    """
+    whl_metadata_file = wheel_file.with_suffix('.whl.metadata')
+
+    with ZipFile(wheel_file, "r") as zf:
+        # Find the METADATA file inside *.dist-info/
+        metadata_file = next(
+            (name for name in zf.namelist() if name.endswith('.dist-info/METADATA')),
+            None
+        )
+        if metadata_file is None:
+            raise FileNotFoundError('No METADATA file found in wheel')
+
+    metadata_bytes = zf.read(metadata_file)
+    whl_metadata_file.write_bytes(metadata_bytes)
+    return whl_metadata_file
 
 
 class MasterStats(namedtuple('MasterStats', (

--- a/piwheels/states.py
+++ b/piwheels/states.py
@@ -814,19 +814,22 @@ class TransferState:
         # clobber any symlink currently in place
         tmp_file.rename(final_name)
         if self._file_state.platform_tag == 'linux_armv7l':
-            # NOTE: dirty hack to symlink the armv7 wheel to the armv6 name;
-            # the slave_driver task expects us to have done this
-            arm6_name = final_name.with_name(
-                final_name.name[:-16] + 'linux_armv6l.whl')
-            try:
-                arm6_name.symlink_to(final_name.name)
-            except FileExistsError:
-                # If the symlink already exists, or if a file with the same
-                # name already exists, ignore the error. In particular, if an
-                # actual file exists (a specific armv6 build) we must NOT
-                # overwrite it
-                pass
+            self.create_armv6_symlink(final_name)
         self._file_state.verified()
+
+    def create_armv6_symlink(self, armv7_path):
+        # NOTE: dirty hack to symlink the armv7 wheel to the armv6 name;
+        # the slave_driver task expects us to have done this
+        arm6_name = armv7_path.with_name(
+            armv7_path.name[:-16] + 'linux_armv6l.whl')
+        try:
+            arm6_name.symlink_to(armv7_path.name)
+        except FileExistsError:
+            # If the symlink already exists, or if a file with the same
+            # name already exists, ignore the error. In particular, if an
+            # actual file exists (e.g. a specific armv6 build) we must NOT
+            # overwrite it
+            pass
 
     def rollback(self):
         Path(self._file.name).unlink()

--- a/piwheels/states.py
+++ b/piwheels/states.py
@@ -828,7 +828,7 @@ class TransferState:
         # NOTE: dirty hack to symlink the armv7 wheel to the armv6 name;
         # the slave_driver task expects us to have done this
         arm6_name = armv7_path.with_name(
-            armv7_path.name[:-16] + 'linux_armv6l.whl')
+            armv7_path.name.replace('linux_armv7l', 'linux_armv6l'))
         try:
             arm6_name.symlink_to(armv7_path.name)
         except FileExistsError:

--- a/piwheels/states.py
+++ b/piwheels/states.py
@@ -74,7 +74,7 @@ import tempfile
 from pathlib import Path
 from datetime import datetime, timezone
 from collections import namedtuple, deque
-from zipfile import ZipFile
+from zipfile import ZipFile, BadZipFile
 
 from .ranges import exclude, intersect
 
@@ -816,7 +816,8 @@ class TransferState:
         tmp_file.rename(final_name)
         try:
             whl_metadata_file = create_wheel_metadata_file(final_name)
-        except Exception:
+        except BadZipFile:
+            logging.error('wheel is not a valid zip: %s', final_name.name)
             whl_metadata_file = None
         if self._file_state.platform_tag == 'linux_armv7l':
             self.create_armv6_symlink(final_name)

--- a/piwheels/states.py
+++ b/piwheels/states.py
@@ -848,6 +848,7 @@ def create_wheel_metadata_file(wheel_file: Path) -> Path:
     .whl.metadata file. Return the path to the new metadata file.
     """
     whl_metadata_file = wheel_file.with_suffix('.whl.metadata')
+    logging.info('Creating wheel metadata file %s', whl_metadata_file)
 
     with ZipFile(wheel_file, "r") as zf:
         # Find the METADATA file inside *.dist-info/

--- a/piwheels/states.py
+++ b/piwheels/states.py
@@ -814,10 +814,14 @@ class TransferState:
         # the case of an actual armv6 build being uploaded, it will (rightly)
         # clobber any symlink currently in place
         tmp_file.rename(final_name)
-        whl_metadata_file = create_wheel_metadata_file(final_name)
+        try:
+            whl_metadata_file = create_wheel_metadata_file(final_name)
+        except Exception:
+            whl_metadata_file = None
         if self._file_state.platform_tag == 'linux_armv7l':
             self.create_armv6_symlink(final_name)
-            self.create_armv6_symlink(whl_metadata_file)
+            if whl_metadata_file is not None:
+                self.create_armv6_symlink(whl_metadata_file)
         self._file_state.verified()
 
     def create_armv6_symlink(self, armv7_path):
@@ -853,8 +857,7 @@ def create_wheel_metadata_file(wheel_file: Path) -> Path:
         )
         if metadata_file is None:
             raise FileNotFoundError('No METADATA file found in wheel')
-
-    metadata_bytes = zf.read(metadata_file)
+        metadata_bytes = zf.read(metadata_file)
     whl_metadata_file.write_bytes(metadata_bytes)
     return whl_metadata_file
 

--- a/tests/audit/test_audit_packages.py
+++ b/tests/audit/test_audit_packages.py
@@ -295,8 +295,7 @@ def test_check_wheel_metadata_file_present(tmpdir):
     metadata = wheel.with_suffix('.whl.metadata')
     metadata.touch()
     config = mock.Mock()
-    config.output_path = Path(str(tmpdir))
-    result = check_wheel_metadata_file(config, 'foo', 'foo-0.1-py3-none-any.whl')
+    result = check_wheel_metadata_file(config, wheel)
     assert result == metadata
     config.missing_file.write.assert_not_called()
 
@@ -307,11 +306,10 @@ def test_check_wheel_metadata_file_missing_reports(tmpdir, caplog):
     wheel = pkg_dir / 'foo-0.1-py3-none-any.whl'
     wheel.touch()
     config = mock.Mock()
-    config.output_path = Path(str(tmpdir))
     config.create_missing_metadata = False
     config.missing_file = None
     with caplog.at_level(logging.ERROR):
-        result = check_wheel_metadata_file(config, 'foo', 'foo-0.1-py3-none-any.whl')
+        result = check_wheel_metadata_file(config, wheel)
     assert result == wheel.with_suffix('.whl.metadata')
     assert not result.exists()
     assert 'missing' in caplog.text
@@ -323,9 +321,8 @@ def test_check_wheel_metadata_file_missing_creates(tmpdir, wheel_bytes):
     wheel = pkg_dir / 'foo-0.1-py3-none-any.whl'
     wheel.write_bytes(wheel_bytes)
     config = mock.Mock()
-    config.output_path = Path(str(tmpdir))
     config.create_missing_metadata = True
-    result = check_wheel_metadata_file(config, 'foo', 'foo-0.1-py3-none-any.whl')
+    result = check_wheel_metadata_file(config, wheel)
     assert result == wheel.with_suffix('.whl.metadata')
     assert result.exists()
     assert result.read_bytes() == WHEEL_METADATA_CONTENT

--- a/tests/audit/test_audit_packages.py
+++ b/tests/audit/test_audit_packages.py
@@ -28,14 +28,16 @@
 
 
 import hashlib
+import logging
 from queue import Queue
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
-from conftest import find_messages
+from conftest import find_messages, WHEEL_METADATA_CONTENT
 from piwheels import __version__
-from piwheels.audit.audit_packages import main
+from piwheels.audit.audit_packages import main, check_wheel_metadata_file
 
 
 @pytest.fixture()
@@ -283,3 +285,47 @@ def test_version(capsys):
 #     assert missing.read_text() == ''
 #     assert extra.read_text() == ''
 #     assert broken.read_text() == ''
+
+
+def test_check_wheel_metadata_file_present(tmpdir):
+    pkg_dir = Path(str(tmpdir)) / 'simple' / 'foo'
+    pkg_dir.mkdir(parents=True)
+    wheel = pkg_dir / 'foo-0.1-py3-none-any.whl'
+    wheel.touch()
+    metadata = wheel.with_suffix('.whl.metadata')
+    metadata.touch()
+    config = mock.Mock()
+    config.output_path = Path(str(tmpdir))
+    result = check_wheel_metadata_file(config, 'foo', 'foo-0.1-py3-none-any.whl')
+    assert result == metadata
+    config.missing_file.write.assert_not_called()
+
+
+def test_check_wheel_metadata_file_missing_reports(tmpdir, caplog):
+    pkg_dir = Path(str(tmpdir)) / 'simple' / 'foo'
+    pkg_dir.mkdir(parents=True)
+    wheel = pkg_dir / 'foo-0.1-py3-none-any.whl'
+    wheel.touch()
+    config = mock.Mock()
+    config.output_path = Path(str(tmpdir))
+    config.create_missing_metadata = False
+    config.missing_file = None
+    with caplog.at_level(logging.ERROR):
+        result = check_wheel_metadata_file(config, 'foo', 'foo-0.1-py3-none-any.whl')
+    assert result == wheel.with_suffix('.whl.metadata')
+    assert not result.exists()
+    assert 'missing' in caplog.text
+
+
+def test_check_wheel_metadata_file_missing_creates(tmpdir, wheel_bytes):
+    pkg_dir = Path(str(tmpdir)) / 'simple' / 'foo'
+    pkg_dir.mkdir(parents=True)
+    wheel = pkg_dir / 'foo-0.1-py3-none-any.whl'
+    wheel.write_bytes(wheel_bytes)
+    config = mock.Mock()
+    config.output_path = Path(str(tmpdir))
+    config.create_missing_metadata = True
+    result = check_wheel_metadata_file(config, 'foo', 'foo-0.1-py3-none-any.whl')
+    assert result == wheel.with_suffix('.whl.metadata')
+    assert result.exists()
+    assert result.read_bytes() == WHEEL_METADATA_CONTENT

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,11 +28,13 @@
 
 
 import os
+from io import BytesIO
 from unittest import mock
 from datetime import datetime, timedelta, timezone
 from hashlib import sha256
 from threading import Thread, Event
 from urllib.parse import urlsplit
+from zipfile import ZipFile
 
 import pytest
 import requests
@@ -81,9 +83,30 @@ def find_messages(records, **kwargs):
             yield record
 
 
+WHEEL_METADATA_CONTENT = b'Metadata-Version: 2.1\nName: foo\nVersion: 0.1\n'
+
+
 @pytest.fixture()
 def file_content(request):
     return b'\x01\x02\x03\x04\x05\x06\x07\x08' * 15432  # 123456 bytes
+
+
+@pytest.fixture()
+def wheel_bytes():
+    buf = BytesIO()
+    with ZipFile(buf, 'w') as zf:
+        zf.writestr('foo-0.1.dist-info/METADATA', WHEEL_METADATA_CONTENT)
+    return buf.getvalue()
+
+
+@pytest.fixture()
+def wheel_file_state(wheel_bytes):
+    h = sha256()
+    h.update(wheel_bytes)
+    return FileState(
+        'foo-0.1-cp34-cp34m-linux_armv7l.whl', len(wheel_bytes),
+        h.hexdigest().lower(), 'foo', '0.1', 'cp34', 'cp34m', 'linux_armv7l',
+        '>=3', {'apt': ['libc6'], 'pip': ['bar']})
 
 
 @pytest.fixture()

--- a/tests/master/test_the_scribe.py
+++ b/tests/master/test_the_scribe.py
@@ -1183,6 +1183,39 @@ def test_delete_version_missing_file(db_queue, task, scribe_queue, master_config
     assert scribe_queue.recv_msg() == ('DONE', None)
 
 
+def test_delete_package_also_deletes_metadata(db_queue, task, scribe_queue, master_config):
+    db_queue.expect('ALLPKGS')
+    db_queue.send('OK', {'foo'})
+    task.once()
+    scribe_queue.send_msg('DELPKG', 'foo')
+    db_queue.expect('GETPKGNAMES', 'foo')
+    db_queue.send('OK', [])
+    db_queue.expect('PKGFILES', 'foo')
+    db_queue.send('OK', {
+        'foo-0.1-cp34-cp34m-linux_armv6l.whl': 'deadbeef',
+        'foo-0.1-cp34-cp34m-linux_armv7l.whl': 'deadbeef',
+    })
+    root = Path(master_config.output_path)
+    index = root / 'simple' / 'foo'
+    index.mkdir(parents=True)
+    project = root / 'project' / 'foo'
+    project.mkdir(parents=True)
+    project_json = project / 'json'
+    project_json.mkdir(parents=True)
+    (index / 'foo-0.1-cp34-cp34m-linux_armv6l.whl').touch()
+    (index / 'foo-0.1-cp34-cp34m-linux_armv6l.whl.metadata').touch()
+    (index / 'foo-0.1-cp34-cp34m-linux_armv7l.whl').touch()
+    (index / 'foo-0.1-cp34-cp34m-linux_armv7l.whl.metadata').touch()
+    (project / 'index.html').touch()
+    (project_json / 'index.json').touch()
+    task.poll(0)
+    db_queue.check()
+    assert not index.exists()
+    assert not project_json.exists()
+    assert not project.exists()
+    assert scribe_queue.recv_msg() == ('DONE', None)
+
+
 def test_delete_package_null(db_queue, task, scribe_queue, master_config):
     # this should never happen, but just in case...
     db_queue.expect('ALLPKGS')

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -33,12 +33,17 @@ from pathlib import Path
 
 import pytest
 
+from io import BytesIO
+from zipfile import ZipFile
+
 from piwheels import const, protocols, transport
 from piwheels.states import (
     SlaveState,
     TransferState,
     mkdir_override_symlink,
+    create_wheel_metadata_file,
 )
+from conftest import WHEEL_METADATA_CONTENT
 
 
 UTC = timezone.utc
@@ -440,3 +445,52 @@ def test_override_symlink_fallback():
     pkg_dir.is_symlink.return_value = True
     pkg_dir.unlink.side_effect = IsADirectoryError
     mkdir_override_symlink(pkg_dir)
+
+
+def test_create_wheel_metadata_file(tmpdir, wheel_bytes):
+    wheel_path = Path(str(tmpdir)) / 'foo-0.1-py3-none-any.whl'
+    wheel_path.write_bytes(wheel_bytes)
+    result = create_wheel_metadata_file(wheel_path)
+    assert result == wheel_path.with_suffix('.whl.metadata')
+    assert result.read_bytes() == WHEEL_METADATA_CONTENT
+
+
+def test_create_wheel_metadata_file_no_metadata(tmpdir):
+    buf = BytesIO()
+    with ZipFile(buf, 'w') as zf:
+        zf.writestr('foo-0.1.dist-info/RECORD', 'some,record,data')
+    wheel_path = Path(str(tmpdir)) / 'foo-0.1-py3-none-any.whl'
+    wheel_path.write_bytes(buf.getvalue())
+    with pytest.raises(FileNotFoundError):
+        create_wheel_metadata_file(wheel_path)
+
+
+def test_transfer_commit_creates_metadata(tmpdir, wheel_file_state, wheel_bytes):
+    tmpdir.mkdir('simple')
+    TransferState.output_path = Path(str(tmpdir))
+    trans_state = TransferState(1, wheel_file_state)
+    trans_state._file.seek(0)
+    trans_state._file.write(wheel_bytes)
+    trans_state._file.flush()
+    trans_state.commit('foo')
+    final_path = TransferState.output_path / 'simple' / 'foo' / wheel_file_state.filename
+    assert final_path.exists()
+    metadata_path = final_path.with_suffix('.whl.metadata')
+    assert metadata_path.exists()
+    assert metadata_path.read_bytes() == WHEEL_METADATA_CONTENT
+
+
+def test_transfer_commit_armv6_creates_metadata_symlink(tmpdir, wheel_file_state, wheel_bytes):
+    tmpdir.mkdir('simple')
+    TransferState.output_path = Path(str(tmpdir))
+    final_path = TransferState.output_path / 'simple' / 'foo' / wheel_file_state.filename
+    trans_state = TransferState(1, wheel_file_state)
+    trans_state._file.seek(0)
+    trans_state._file.write(wheel_bytes)
+    trans_state._file.flush()
+    trans_state.commit('foo')
+    metadata_path = final_path.with_suffix('.whl.metadata')
+    assert metadata_path.exists()
+    arm6_metadata = metadata_path.with_name('foo-0.1-cp34-cp34m-linux_armv6l.whl.metadata')
+    assert arm6_metadata.is_symlink()
+    assert arm6_metadata.resolve() == metadata_path

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -40,6 +40,7 @@ from piwheels import const, protocols, transport
 from piwheels.states import (
     SlaveState,
     TransferState,
+    FileState,
     mkdir_override_symlink,
     create_wheel_metadata_file,
 )
@@ -494,3 +495,28 @@ def test_transfer_commit_armv6_creates_metadata_symlink(tmpdir, wheel_file_state
     arm6_metadata = metadata_path.with_name('foo-0.1-cp34-cp34m-linux_armv6l.whl.metadata')
     assert arm6_metadata.is_symlink()
     assert arm6_metadata.resolve() == metadata_path
+
+
+def _make_file_state(content):
+    from hashlib import sha256
+    h = sha256()
+    h.update(content)
+    return FileState(
+        'foo-0.1-py3-none-any.whl', len(content),
+        h.hexdigest().lower(), 'foo', '0.1', 'py3', 'none', 'any', None, {})
+
+
+def test_transfer_commit_bad_zip_logs_error(tmpdir, caplog):
+    content = b'\x00' * 256
+    tmpdir.mkdir('simple')
+    TransferState.output_path = Path(str(tmpdir))
+    trans_state = TransferState(1, _make_file_state(content))
+    trans_state._file.seek(0)
+    trans_state._file.write(content)
+    trans_state._file.flush()
+    with caplog.at_level('ERROR'):
+        trans_state.commit('foo')
+    final_path = TransferState.output_path / 'simple' / 'foo' / 'foo-0.1-py3-none-any.whl'
+    assert final_path.exists()
+    assert not final_path.with_suffix('.whl.metadata').exists()
+    assert 'not a valid zip' in caplog.text


### PR DESCRIPTION
[PEP-658](https://peps.python.org/pep-0658/) allows repositories to provide metadata files alongside wheels, so that installers can use the metadata to discard candidates without downloading the whole wheel.

In order to be able to serve metadata files separately, we need the mechanism to create them after building a wheel, and to create them on existing wheels, as well as recreate missing ones as part of the audit process.

Once we're sure all wheels have metadata files, we can enable this feature by adding an attribute to each link in the simple index. This will be a separate PR (#394).