### PR TITLE
PEP-658 simple index

### DIFF
--- a/piwheels/master/templates/simple_package.pt
+++ b/piwheels/master/templates/simple_package.pt
@@ -6,7 +6,7 @@
 <body>
 <h1>Links for ${package}</h1>
 
-<span tal:repeat="row files" tal:omit-tag="1"><a href="${row.file_url}#sha256=${row.filehash}" tal:attributes="data-yanked '' if row.yanked else None; data-requires-python row.requires_python if row.requires_python else None">${row.filename}</a><br></span>
+<span tal:repeat="row files" tal:omit-tag="1"><a href="${row.file_url}#sha256=${row.filehash}" tal:attributes="data-dist-info-metadata ''; data-yanked '' if row.yanked else None; data-requires-python row.requires_python if row.requires_python else None">${row.filename}</a><br></span>
 </body>
 </html>
 <!--${now.isoformat()}-->


### PR DESCRIPTION
This PR adds the `dist-info-metadata` attribute to each wheel's link tag for [PEP-658](https://peps.python.org/pep-0658/)

Should be merged after #393 is deployed and the backfill of metadata files is completed.