### PR TITLE
Fix unhandled ConnectionError when fetching blog posts

### DIFF
--- a/piwheels/master/the_scribe.py
+++ b/piwheels/master/the_scribe.py
@@ -710,10 +710,10 @@ class TheScribe(tasks.PauseableTask):
         """
         blog_url = "https://blog.piwheels.org"
         blog_json_url = f"{blog_url}/posts.json"
-        response = requests.get(blog_json_url)
         try:
+            response = requests.get(blog_json_url, timeout=10)
             response.raise_for_status()
-        except requests.HTTPError as exc:
+        except requests.RequestException as exc:
             self.logger.error('Failed to fetch blog posts: %s', exc)
             return []
         data = response.json()


### PR DESCRIPTION
- Fixes #410

`requests.get()` to the blog's `posts.json` endpoint sat outside the `try/except` and only `requests.HTTPError` was caught, so a connection failure (e.g. blog.piwheels.org unreachable) propagated uncaught and crashed piw-master. Catch `requests.RequestException` instead, and add a timeout to avoid hanging indefinitely.