### PR TITLE
Fix piw-monitor freeze from unbounded GraphBar history loop

### DIFF
--- a/piwheels/widgets/charts.py
+++ b/piwheels/widgets/charts.py
@@ -247,6 +247,15 @@ class GraphBar(ur.Widget):
     _sizing = frozenset([ur.FLOW])
     ignore_focus = True
 
+    # Upper bound on the number of history bins computed by update(). Without
+    # this, a single bogus or out-of-sync timestamp in *stats* (e.g. a slave
+    # reporting a clock far in the past or future) can make
+    # ceil((timestamps[-1] - timestamps[0]) / delta) enormous, causing update()
+    # to iterate for a very long time and freeze the UI. Rendering only ever
+    # uses the most recent portion of the history (bounded by the terminal
+    # width), so bins beyond this cap would never be displayed anyway.
+    max_bins = 1000
+
     def __init__(self, minimum=None, maximum=None, format=' {min}-{max}',
                  delta=timedelta(minutes=1), chars=' ▁▂▃▄▅▆▇█', bar_align='<'):
         super().__init__()
@@ -279,7 +288,10 @@ class GraphBar(ur.Widget):
             finish = len(timestamps) - 1
             value = readings[finish]
             history = []
-            for i in range(ceil((timestamps[-1] - timestamps[0]) / self.delta)):
+            bins = min(
+                ceil((timestamps[-1] - timestamps[0]) / self.delta),
+                self.max_bins)
+            for i in range(bins):
                 start = bisect_left(timestamps, timestamps[-1] - i * self.delta)
                 values = sorted(readings[start:finish])
                 if values:


### PR DESCRIPTION
## Summary

- `piw-monitor` could freeze (appearing to hang, requiring Ctrl+C) when switching between slaves in the TUI.
- Root cause: `GraphBar.update()` in `piwheels/widgets/charts.py` loops once per `delta`-sized bin across the full span between a slave's oldest and newest stats timestamp. If a slave reports a bogus or clock-skewed timestamp (e.g. a Pi without RTC/NTP sync briefly reporting a near-epoch time), that span can balloon to years, turning the loop into effectively unbounded work and blocking urwid's single-threaded event loop.
- Fixes it by capping the loop at `GraphBar.max_bins = 1000`. Rendering only ever consumes the most recent portion of history anyway (bounded by terminal width), so this doesn't change behaviour in the normal case.

## Test plan

- [x] Reproduced the pathological case locally (stats list with a near-epoch timestamp mixed with recent ones) — confirmed `update()` used to be effectively unbounded and now completes instantly, capped at 1000 bins.
- [x] Confirmed normal-case history output is unchanged for typical evenly-spaced stats (99 bins for 100 readings at 15s delta).
- [x] Verify in production monitor against a slave that exhibits clock skew.