### PR TITLE
Prevent master crash on overlong package/version names

### DIFF
--- a/piwheels/add/__init__.py
+++ b/piwheels/add/__init__.py
@@ -170,6 +170,16 @@ def do_add(config):
                 raise RuntimeError(
                     'Cannot yank a known version with piw-add - use '
                     'piw-remove instead')
+            elif data == 'BADPKG':
+                raise RuntimeError(
+                    'Package name too long (max 200 characters)')
+            elif data == 'BADVER':
+                raise RuntimeError(
+                    'Version string too long (max 200 characters)')
+            elif data == 'INTERNAL':
+                raise RuntimeError(
+                    'An internal error occurred on the master; check its '
+                    'logs')
             else:
                 assert False, 'invalid data from master'
 

--- a/piwheels/master/mr_chase.py
+++ b/piwheels/master/mr_chase.py
@@ -129,7 +129,15 @@ class MrChase(tasks.PauseableTask):
             'REBUILD': self.do_rebuild,
             'SENT':    self.do_sent,
         }[msg]
-        msg, data = handler(state)
+        try:
+            msg, data = handler(state)
+        except Exception:
+            # A bad manual request (e.g. from piw-add/piw-remove) shouldn't be
+            # able to take down the entire master; log it and report a clean
+            # error to the client instead of letting the exception propagate
+            # into Task.run(), which would shut down the whole process.
+            self.logger.exception('error handling %s message', msg)
+            msg, data = 'ERROR', 'INTERNAL'
 
         if msg in ('DONE', 'ERROR'):
             self.states.pop(address, None)
@@ -219,6 +227,12 @@ class MrChase(tasks.PauseableTask):
         """
         display_name, description, skip, unskip, aliases = state
         package = canonicalize_name(display_name)
+        if len(package) > 200:
+            # Matches cloud_gazer's own guard (piwheels/master/cloud_gazer.py):
+            # the packages table is VARCHAR(200), so longer names can't be
+            # inserted.
+            self.logger.error('package name too long: %s', package)
+            return 'ERROR', 'BADPKG'
         aliases = set(aliases) | {package, display_name}
         # Ensure display_name sorts last, so it is treated as display name
         aliases = sorted(aliases, key=lambda s: s == display_name)
@@ -252,6 +266,13 @@ class MrChase(tasks.PauseableTask):
             yank, unyank, aliases
         ) = state
         package = canonicalize_name(display_name)
+        if len(version) > 200:
+            # Matches cloud_gazer's own guard (piwheels/master/cloud_gazer.py):
+            # the versions table is VARCHAR(200), so longer strings can't be
+            # inserted. PyPI itself enforces no length limit on versions, so
+            # this does happen with real packages.
+            self.logger.error('version too long: %s %s', package, version)
+            return 'ERROR', 'BADVER'
         aliases = set(aliases) | {package, display_name}
         # Ensure display_name sorts last, so it is treated as display name
         aliases = sorted(aliases, key=lambda s: s == display_name)

--- a/piwheels/remove/__init__.py
+++ b/piwheels/remove/__init__.py
@@ -126,6 +126,10 @@ def do_remove(config):
             elif data == 'NOVER':
                 raise RuntimeError('Version {} {} does not exist'.format(
                     config.package, config.version))
+            elif data == 'INTERNAL':
+                raise RuntimeError(
+                    'An internal error occurred on the master; check its '
+                    'logs')
             else:
                 assert False, 'invalid data from master'
 

--- a/tests/add/test_add.py
+++ b/tests/add/test_add.py
@@ -207,6 +207,22 @@ def test_skip_known_package(mock_json_server, mock_context, import_queue_name,
                     'piw-remove instead') in str(exc.value)
 
 
+def test_add_package_name_too_long(mock_json_server, mock_context,
+                                    import_queue_name, import_queue):
+    name = 'a' * 201
+    with mock.patch('piwheels.terminal.yes_no_prompt') as prompt_mock:
+        prompt_mock.return_value = True
+        mock_json_server[name] = 'DESCRIPTION'
+        with AddThread(['--import-queue', import_queue_name, name]) as thread:
+            assert import_queue.recv_msg() == ('ADDPKG',
+                [name, 'DESCRIPTION', '', False, []]
+            )
+            import_queue.send_msg('ERROR', 'BADPKG')
+            with pytest.raises(RuntimeError) as exc:
+                thread.join(10)
+            assert 'Package name too long' in str(exc.value)
+
+
 def test_unskip_known_package(mock_json_server, mock_context,
                               import_queue_name, import_queue):
     with mock.patch('piwheels.terminal.yes_no_prompt') as prompt_mock:
@@ -251,6 +267,43 @@ def test_add_version(mock_context, import_queue_name, import_queue):
                 import_queue.send_msg('DONE', 'NEWVER')
                 thread.join(10)
                 assert thread.exitcode == 0
+
+
+def test_add_version_too_long(mock_context, import_queue_name, import_queue):
+    version = '3' + '.14159' * 40
+    with mock.patch('piwheels.terminal.yes_no_prompt') as prompt_mock:
+        prompt_mock.return_value = True
+        with mock.patch('piwheels.add.datetime') as dt:
+            dt.now.return_value = datetime(2021, 1, 1)
+            dt.strptime.side_effect = datetime.strptime
+            with AddThread(['--import-queue', import_queue_name,
+                            'foo', version]) as thread:
+                assert import_queue.recv_msg() == ('ADDVER', [
+                    'foo', version, '', False,
+                    datetime(2021, 1, 1, tzinfo=UTC), False, False, []
+                ])
+                import_queue.send_msg('ERROR', 'BADVER')
+                with pytest.raises(RuntimeError) as exc:
+                    thread.join(10)
+                assert 'Version string too long' in str(exc.value)
+
+
+def test_add_internal_error(mock_context, import_queue_name, import_queue):
+    with mock.patch('piwheels.terminal.yes_no_prompt') as prompt_mock:
+        prompt_mock.return_value = True
+        with mock.patch('piwheels.add.datetime') as dt:
+            dt.now.return_value = datetime(2021, 1, 1)
+            dt.strptime.side_effect = datetime.strptime
+            with AddThread(['--import-queue', import_queue_name,
+                            'foo', '0.1']) as thread:
+                assert import_queue.recv_msg() == ('ADDVER', [
+                    'foo', '0.1', '', False,
+                    datetime(2021, 1, 1, tzinfo=UTC), False, False, []
+                ])
+                import_queue.send_msg('ERROR', 'INTERNAL')
+                with pytest.raises(RuntimeError) as exc:
+                    thread.join(10)
+                assert 'internal error' in str(exc.value)
 
 
 def test_add_and_skip_version(mock_context, import_queue_name, import_queue):

--- a/tests/master/test_mr_chase.py
+++ b/tests/master/test_mr_chase.py
@@ -431,6 +431,38 @@ def test_add_version_no_package(db_queue, task, import_queue):
     db_queue.check()
 
 
+def test_add_package_name_too_long(db_queue, task, import_queue):
+    name = 'a' * 201
+    import_queue.send_msg('ADDPKG', [name, 'silly name', '', False, []])
+    task.poll(0)
+    assert import_queue.recv_msg() == ('ERROR', 'BADPKG')
+    assert len(task.states) == 0
+    db_queue.check()
+
+
+def test_add_version_too_long(db_queue, task, import_queue):
+    released = datetime(2000, 1, 1, 12, 34, tzinfo=UTC)
+    version = '3' + '.14159' * 40
+    import_queue.send_msg(
+        'ADDVER', ['Foo', version, '', False, released, False, False, []])
+    task.poll(0)
+    assert import_queue.recv_msg() == ('ERROR', 'BADVER')
+    assert len(task.states) == 0
+    db_queue.check()
+
+
+def test_handle_import_unexpected_error(db_queue, task, import_queue):
+    import_queue.send_msg('ADDPKG', ['Foo', 'foos things', '', False, []])
+    db_queue.expect('NEWPKG', ['foo', '', 'foos things'])
+    db_queue.send('ERROR', 'unexpected failure')
+    task.logger = mock.Mock()
+    task.poll(0)
+    assert import_queue.recv_msg() == ('ERROR', 'INTERNAL')
+    assert len(task.states) == 0
+    assert task.logger.exception.call_count == 1
+    db_queue.check()
+
+
 def test_unskip_version(db_queue, web_queue, task, import_queue):
     now = datetime.now(tz=UTC)
     released = datetime(2000, 1, 1, 12, 34, tzinfo=UTC)

--- a/tests/remove/test_remove.py
+++ b/tests/remove/test_remove.py
@@ -134,6 +134,17 @@ def test_remove_missing_package(mock_context, import_queue_name, import_queue):
             assert 'Package foo does not exist' in str(exc.value)
 
 
+def test_remove_internal_error(mock_context, import_queue_name, import_queue):
+    with mock.patch('piwheels.terminal.yes_no_prompt') as prompt_mock:
+        prompt_mock.return_value = True
+        with RemoveThread(['--import-queue', import_queue_name, 'foo']) as thread:
+            assert import_queue.recv_msg() == ('REMPKG', ['foo', False, ''])
+            import_queue.send_msg('ERROR', 'INTERNAL')
+            with pytest.raises(RuntimeError) as exc:
+                thread.join(10)
+            assert 'internal error' in str(exc.value)
+
+
 def test_skip_package(mock_context, import_queue_name, import_queue):
     with mock.patch('piwheels.terminal.yes_no_prompt') as prompt_mock:
         prompt_mock.return_value = True


### PR DESCRIPTION
Adding a package or version whose name exceeds the `VARCHAR(200)` column limit (e.g. a real PyPI release with a 217-character version string) raised an unhandled DB exception in `MrChase.handle_import`, which propagated into `Task.run()`'s bare except and shut down the entire master process. `cloud_gazer` already guards against this; `mr_chase` did not.

Add the same length checks to `do_add_package`/`do_add_version`, returning a clean `ERROR` response instead. Also wrap `handle_import`'s dispatch in try/except as a general safety net, so no future unexpected error in a manual import/remove request can take down the master.