### PR TITLE
Remove searches table and search logging

### DIFF
--- a/piwheels/initdb/sql/create_piwheels.sql
+++ b/piwheels/initdb/sql/create_piwheels.sql
@@ -20,7 +20,7 @@ CREATE TABLE configuration (
     CONSTRAINT config_pk PRIMARY KEY (id)
 );
 
-INSERT INTO configuration(id, version) VALUES (1, '0.26');
+INSERT INTO configuration(id, version) VALUES (1, '0.27');
 GRANT SELECT ON configuration TO {username};
 
 -- packages
@@ -266,31 +266,6 @@ CREATE TABLE metadata_downloads (
 CREATE INDEX metadata_downloads_files ON metadata_downloads(filename);
 CREATE INDEX metadata_downloads_accessed_at ON metadata_downloads(accessed_at DESC);
 GRANT SELECT ON metadata_downloads TO {username};
-
--- searches
--------------------------------------------------------------------------------
--- The "searches" table tracks the searches made against piwheels by users.
--------------------------------------------------------------------------------
-
-CREATE TABLE searches (
-    package             VARCHAR(200) NOT NULL,
-    accessed_by         INET NOT NULL,
-    accessed_at         TIMESTAMP NOT NULL,
-    arch                VARCHAR(100) DEFAULT NULL,
-    distro_name         VARCHAR(100) DEFAULT NULL,
-    distro_version      VARCHAR(100) DEFAULT NULL,
-    os_name             VARCHAR(100) DEFAULT NULL,
-    os_version          VARCHAR(100) DEFAULT NULL,
-    py_name             VARCHAR(100) DEFAULT NULL,
-    py_version          VARCHAR(100) DEFAULT NULL,
-    installer_name      VARCHAR(20) DEFAULT NULL,
-    installer_version   VARCHAR(100) DEFAULT NULL,
-    setuptools_version  VARCHAR(100) DEFAULT NULL
-);
-
-CREATE INDEX searches_package ON searches(package);
-CREATE INDEX searches_accessed_at ON searches(accessed_at DESC);
-GRANT SELECT ON searches TO {username};
 
 -- project_page_hits
 -------------------------------------------------------------------------------
@@ -1103,75 +1078,6 @@ REVOKE ALL ON FUNCTION log_metadata_download(
     TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT
     ) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION log_metadata_download(
-    TEXT, INET, TIMESTAMP,
-    TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT
-    ) TO {username};
-
--- log_search(package, accessed_by, accessed_at, arch, distro_name,
---              distro_version, os_name, os_version, py_name, py_version,
---              installer_name, installer_version, setuptools_version)
--------------------------------------------------------------------------------
--- Adds a new entry to the searches table.
--------------------------------------------------------------------------------
-
-CREATE FUNCTION log_search(
-    package TEXT,
-    accessed_by INET,
-    accessed_at TIMESTAMP,
-    arch TEXT = NULL,
-    distro_name TEXT = NULL,
-    distro_version TEXT = NULL,
-    os_name TEXT = NULL,
-    os_version TEXT = NULL,
-    py_name TEXT = NULL,
-    py_version TEXT = NULL,
-    installer_name TEXT = NULL,
-    installer_version TEXT = NULL,
-    setuptools_version TEXT = NULL
-)
-    RETURNS VOID
-    LANGUAGE SQL
-    CALLED ON NULL INPUT
-    SECURITY DEFINER
-    SET search_path = public, pg_temp
-AS $sql$
-    INSERT INTO searches (
-        package,
-        accessed_by,
-        accessed_at,
-        arch,
-        distro_name,
-        distro_version,
-        os_name,
-        os_version,
-        py_name,
-        py_version,
-        installer_name,
-        installer_version,
-        setuptools_version
-    )
-    VALUES (
-        package,
-        accessed_by,
-        accessed_at,
-        arch,
-        distro_name,
-        distro_version,
-        os_name,
-        os_version,
-        py_name,
-        py_version,
-        installer_name,
-        installer_version,
-        setuptools_version
-    );
-$sql$;
-
-REVOKE ALL ON FUNCTION log_search(
-    TEXT, INET, TIMESTAMP,
-    TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT
-    ) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION log_search(
     TEXT, INET, TIMESTAMP,
     TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT
     ) TO {username};

--- a/piwheels/initdb/sql/update_piwheels_0.26_to_0.27.sql
+++ b/piwheels/initdb/sql/update_piwheels_0.26_to_0.27.sql
@@ -1,0 +1,8 @@
+UPDATE configuration SET version = '0.27';
+
+DROP FUNCTION log_search(
+  TEXT, INET, TIMESTAMP,
+  TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT
+);
+
+DROP TABLE searches;

--- a/piwheels/logger/__init__.py
+++ b/piwheels/logger/__init__.py
@@ -76,7 +76,6 @@ log_type_patterns = [
     LogType(None,    '/project/', None),
     LogType(None, '/simple/*.whl.metadata', 'LOGMETADATA'),
     LogType(None, '/simple/*.whl', 'LOGDOWNLOAD'),
-    LogType('pip/*', '/simple/*', 'LOGSEARCH'),
     LogType(None,    '/simple/*', None),
     LogType(None,    '/project/*/json/*', 'LOGJSON'),
     LogType(None,    '/project/*', 'LOGPROJECT'),
@@ -240,22 +239,6 @@ def log_transform(row, log_type, decoder=json.JSONDecoder()):
     elif log_type == 'LOGMETADATA':
         return [
             path.with_suffix('').name,
-            get_access_ip(row.remote_host),
-            get_access_time(row.time),
-            get_arch(user_data),
-            get_distro_name(user_data),
-            get_distro_version(user_data),
-            get_os_name(user_data),
-            get_os_version(user_data),
-            get_py_name(user_data),
-            get_py_version(user_data),
-            get_installer_name(user_data),
-            get_installer_version(user_data),
-            get_setuptools_version(user_data),
-        ]
-    elif log_type == 'LOGSEARCH':
-        return [
-            get_package_name(path),
             get_access_ip(row.remote_host),
             get_access_time(row.time),
             get_arch(user_data),

--- a/piwheels/master/db.py
+++ b/piwheels/master/db.py
@@ -48,7 +48,7 @@ from sqlalchemy.exc import SAWarning
 
 from .. import __version__, protocols
 from ..states import (
-    BuildState, DownloadState, DownloadMetadataState, SearchState,
+    BuildState, DownloadState, DownloadMetadataState,
     ProjectState, JSONState, PageState)
 
 
@@ -394,33 +394,6 @@ class Database:
                     sanitize(download.installer_name),
                     sanitize(download.installer_version),
                     sanitize(download.setuptools_version),
-                ))
-
-    @rpc('LOGSEARCH',
-         lambda args: args[1].as_message(),
-         lambda data: (SearchState.from_message(data),))
-    def log_search(self, search):
-        """
-        Log a search in the database, including data derived from JSON in
-        pip's user-agent.
-        """
-        with self._conn.begin():
-            self._conn.execute(
-                "VALUES (log_search(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s))",
-                (
-                    sanitize(search.package),
-                    search.host,
-                    search.timestamp.astimezone(UTC).replace(tzinfo=None),
-                    sanitize(search.arch),
-                    sanitize(search.distro_name),
-                    sanitize(search.distro_version),
-                    sanitize(search.os_name),
-                    sanitize(search.os_version),
-                    sanitize(search.py_name),
-                    sanitize(search.py_version),
-                    sanitize(search.installer_name),
-                    sanitize(search.installer_version),
-                    sanitize(search.setuptools_version),
                 ))
 
     @rpc('LOGPROJECT',

--- a/piwheels/master/lumberjack.py
+++ b/piwheels/master/lumberjack.py
@@ -37,7 +37,7 @@ from datetime import timedelta
 
 from .. import protocols, transport, tasks
 from ..states import (
-    DownloadState, DownloadMetadataState, SearchState, ProjectState,
+    DownloadState, DownloadMetadataState, ProjectState,
     JSONState, PageState)
 from .the_oracle import DbClient
 
@@ -65,7 +65,6 @@ class Lumberjack(tasks.PauseableTask):
         self.access_handlers = {
             'LOGDOWNLOAD':          (DownloadState,         self.db.log_download,          'downloads'),
             'LOGMETADATA':          (DownloadMetadataState, self.db.log_metadata_download, 'metadata downloads'),
-            'LOGSEARCH':            (SearchState,           self.db.log_search,            'searches'),
             'LOGPROJECT':           (ProjectState,          self.db.log_project,           'project hits'),
             'LOGJSON':              (JSONState,             self.db.log_json,              'JSON hits'),
             'LOGPAGE':              (PageState,             self.db.log_page,              'page hits'),

--- a/piwheels/protocols.py
+++ b/piwheels/protocols.py
@@ -204,23 +204,6 @@ _download_state = ExactSequence([
 ])
 
 
-_search_state = ExactSequence([
-    str,              # package
-    str,              # host
-    dt.datetime,      # timestamp
-    Any(str, None),   # arch
-    Any(str, None),   # distro_name
-    Any(str, None),   # distro_version
-    Any(str, None),   # os_name
-    Any(str, None),   # os_version
-    Any(str, None),   # py_name
-    Any(str, None),   # py_version
-    Any(str, None),   # installer_name
-    Any(str, None),   # installer_version
-    Any(str, None),   # setuptools_version
-])
-
-
 _project_state = ExactSequence([
     str,              # package
     str,              # host
@@ -352,7 +335,6 @@ mr_chase = Protocol(recv={
 lumberjack = Protocol(recv={
     'LOGDOWNLOAD': _download_state,
     'LOGMETADATA': _download_state,
-    'LOGSEARCH': _search_state,
     'LOGPROJECT': _project_state,
     'LOGJSON': _json_state,
     'LOGPAGE': _page_state,
@@ -393,7 +375,6 @@ the_oracle = Protocol(recv={
     'UNYANKVER':   ExactSequence([str, str]),  # package, version
     'LOGDOWNLOAD': _download_state,
     'LOGMETADATA': _download_state,
-    'LOGSEARCH':   _search_state,
     'LOGPROJECT':  _project_state,
     'LOGJSON':     _json_state,
     'LOGPAGE':     _page_state,

--- a/piwheels/states.py
+++ b/piwheels/states.py
@@ -47,9 +47,6 @@ artifacts (:class:`FileState`) and various loggers.
 .. autoclass:: DownloadState
     :members:
 
-.. autoclass:: SearchState
-    :members:
-
 .. autoclass:: ProjectState
     :members:
 
@@ -1015,85 +1012,6 @@ class DownloadMetadataState(namedtuple('DownloadMetadataState', (
     Represents the state of the log entry for a metadata file fetch, i.e. a
     request for a ``.whl.metadata`` file (PEP 658). The :attr:`filename` field
     holds the wheel filename with ``.metadata`` stripped.
-    """
-    __slots__ = ()
-
-    def as_message(self):
-        return list(self)
-
-    @classmethod
-    def from_message(cls, value):
-        return cls(*value)
-
-
-class SearchState(namedtuple('SearchState', (
-    'package',
-    'host',
-    'timestamp',
-    'arch',
-    'distro_name',
-    'distro_version',
-    'os_name',
-    'os_version',
-    'py_name',
-    'py_version',
-    'installer_name',
-    'installer_version',
-    'setuptools_version',
-))):
-    """
-    Represents the state of the log entry for an instance of a package search,
-    including the :attr:`package` name, user's :attr:`host` IP, access
-    :attr:`timestamp` and information about the operating system and installer.
-
-    :param str package:
-        The name of the package searched for.
-
-    :param str host:
-        The hostname or IP address of the user.
-
-    :param datetime.datetime timestamp:
-        The timestamp at which the search occurred.
-
-    :type arch: str or None
-    :param arch:
-        The architecture of the user's computer system (usually armv6 or armv7).
-
-    :type distro_name: str or None
-    :param distro_name:
-        The user's operating system distribution name (e.g. Raspbian).
-
-    :type distro_version: str or None
-    :param distro_version:
-        The version of the user's operating system distribution.
-
-    :type os_name: str or None
-    :param os_name:
-        The name of the user's operating system (e.g. Linux).
-
-    :type os_version: str or None
-    :param os_version:
-        The version of the user's operating system (e.g. Linux kernel version).
-
-    :type py_name: str or None
-    :param py_name:
-        The Python implementation used (e.g. CPython).
-
-    :type py_version: str or None
-    :param py_version:
-        The Python version used (e.g. 3.7.3).
-
-    :type installer_name: str or None
-    :param installer_name:
-        The name of the tool used (e.g. pip).
-
-    :type installer_version: str or None
-    :param installer_version:
-        The version of the tool (e.g. pip) used.
-
-    :type setuptools_version: str or None
-    :param setuptools_version:
-        The version of setuptools used.
     """
     __slots__ = ()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ from requests.exceptions import HTTPError
 
 from piwheels import const, transport, protocols
 from piwheels.states import (
-    BuildState, FileState, DownloadState, DownloadMetadataState, SearchState,
+    BuildState, FileState, DownloadState, DownloadMetadataState,
     ProjectState, JSONState, PageState
 )
 from piwheels.protocols import NoData
@@ -224,17 +224,6 @@ def download_metadata_state(request):
         datetime(2018, 1, 1, 0, 0, 0, tzinfo=UTC), 'armv7l',
         'Raspbian', '9', 'Linux', '', 'CPython', '3.5',
         'pip', None, None)
-
-
-@pytest.fixture()
-def search_state(request):
-    return SearchState(
-        'markupsafe',
-        '2a00:1098:0:80:1000:3b:1:1',
-        datetime(2019, 3, 18, 14, 24, 56, tzinfo=UTC),
-        'armv7l', 'Raspbian GNU/Linux', '9', 'Linux', '4.14.79-v7+',
-        'CPython', '3.5.3', 'pip', '9.0.1', None,
-    )
 
 
 @pytest.fixture()

--- a/tests/logger/test_logger.py
+++ b/tests/logger/test_logger.py
@@ -72,20 +72,8 @@ def log_sample():
 2a00:1098:0:82:1000:3b:1:1 - - [11/Oct/2019:06:27:56 +0100] "GET /logs/0000/0001/0001.txt HTTP/1.1" 200 16384 "-" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1"
 """
     entries = [
-        ('LOGSEARCH', [
-            'markupsafe',
-            '2a00:1098:0:80:1000:3b:1:1',
-            datetime(2019, 3, 18, 14, 24, 56, tzinfo=UTC),
-            'armv7l', 'Raspbian GNU/Linux', '9', 'Linux', '4.14.79-v7+',
-            'CPython', '3.5.3', 'pip', '9.0.1', None,
-        ]),
-        ('LOGSEARCH', [
-            'certifi',
-            '2a00:1098:0:80:1000:3b:1:1',
-            datetime(2019, 3, 18, 14, 24, 56, tzinfo=UTC),
-            'armv7l', 'Raspbian GNU/Linux', '9', 'Linux', '4.14.98-v7+',
-            'CPython', '2.7.13', 'pip', '19.0.3', '40.8.0',
-        ]),
+        # The package index page hits (e.g. /simple/markupsafe/) produce no
+        # entries
         ('LOGDOWNLOAD', [
             'MarkupSafe-1.1.1-cp35-cp35m-linux_armv7l.whl',
             '2a00:1098:0:80:1000:3b:1:1',
@@ -93,54 +81,12 @@ def log_sample():
             'armv7l', 'Raspbian GNU/Linux', '9', 'Linux', '4.14.79-v7+',
             'CPython', '3.5.3', 'pip', '9.0.1', None,
         ]),
-        ('LOGSEARCH', [
-            'asn1crypto',
-            '2a00:1098:0:80:1000:3b:1:1',
-            datetime(2019, 3, 18, 14, 24, 56, tzinfo=UTC),
-            'armv7l', 'Raspbian GNU/Linux', '9', 'Linux', '4.14.79-v7+',
-            'CPython', '2.7.13', 'pip', '9.0.1', None,
-        ]),
-        ('LOGSEARCH', [
-            'backports-abc',
-            '2a00:1098:0:80:1000:3b:1:1',
-            datetime(2019, 3, 18, 14, 24, 57, tzinfo=UTC),
-            'armv7l', 'Raspbian GNU/Linux', '9', 'Linux', '4.14.98-v7+',
-            'CPython', '2.7.13', 'pip', '19.0.3', '40.8.0',
-        ]),
-        ('LOGSEARCH', [
-            'pip',
-            '2a00:1098:0:82:1000:3b:1:1',
-            datetime(2019, 3, 18, 14, 24, 58, tzinfo=UTC),
-            'armv7l', 'Raspbian GNU/Linux', '9', 'Linux', '4.14.98-v7+',
-            'CPython', '3.5.3', 'pip', '19.0.3', '33.1.1',
-        ]),
         ('LOGDOWNLOAD', [
             'PyYAML-3.13-cp35-cp35m-linux_armv7l.whl',
             '2a00:1098:0:80:1000:3b:1:1',
             datetime(2019, 3, 18, 14, 26, 4, tzinfo=UTC),
             'armv7l', 'Raspbian GNU/Linux', '9', 'Linux', '4.19.27-v7+',
             'CPython', '3.5.3', 'pip', '19.0.3', '33.1.1',
-        ]),
-        ('LOGSEARCH', [
-            'pip',
-            '80.229.34.140',
-            datetime(2019, 3, 18, 14, 26, 5, tzinfo=UTC),
-            'armv6l', 'Raspbian GNU/Linux', '9', 'Linux', '4.14.52+',
-            'CPython', '2.7.13', 'pip', '18.0', '40.0.0',
-        ]),
-        ('LOGSEARCH', [
-            'lxml',
-            '2a00:1098:0:80:1000:3b:1:1',
-            datetime(2019, 3, 18, 14, 26, 6, tzinfo=UTC),
-            'armv7l', 'Raspbian GNU/Linux', '9', 'Linux', '4.9.93-linuxkit-aufs',
-            'CPython', '3.6.8', 'pip', '19.0.3', '40.8.0',
-        ]),
-        ('LOGSEARCH', [
-            'cffi',
-            '2a00:1098:0:82:1000:3b:1:1',
-            datetime(2019, 3, 18, 14, 26, 6, tzinfo=UTC),
-            'armv7l', 'Raspbian GNU/Linux', '9', 'Linux', '4.14.79-v7+',
-            'CPython', '2.7.13', 'pip', '9.0.1', None,
         ]),
         ('LOGMETADATA', [
             'foo-0.1-cp34-none-any.whl',
@@ -284,7 +230,7 @@ def test_drop_entries(logger_queue_name, logger_queue, log_sample, tmpdir):
         main_thread.start()
         with io.open(fifo, 'w') as f:
             for _ in range(10000):
-                f.write(log[0])
+                f.write(log[2])
                 if logging.warning.called:
                     if logging.warning.call_args == mock.call('dropping log entry'):
                         break

--- a/tests/master/test_db.py
+++ b/tests/master/test_db.py
@@ -230,16 +230,6 @@ def test_log_metadata_download(db_intf, db, download_metadata_state):
         "SELECT filename FROM metadata_downloads").first() == (download_metadata_state.filename,)
 
 
-def test_log_search(db_intf, db, with_files, search_state):
-    assert db.execute(
-        "SELECT COUNT(*) FROM searches").first() == (0,)
-    db_intf.log_search(search_state)
-    assert db.execute(
-        "SELECT COUNT(*) FROM searches").first() == (1,)
-    assert db.execute(
-        "SELECT package FROM searches").first() == (search_state.package,)
-
-
 def test_log_project_page_hit(db_intf, db, with_files, project_state):
     assert db.execute(
         "SELECT COUNT(*) FROM project_page_hits").first() == (0,)

--- a/tests/master/test_lumberjack.py
+++ b/tests/master/test_lumberjack.py
@@ -79,15 +79,6 @@ def test_log_valid_metadata_download(db_queue, log_queue, stats_queue,
     db_queue.check()
 
 
-def test_log_valid_search(db_queue, log_queue, stats_queue, search_state,
-                          task):
-    log_queue.send_msg('LOGSEARCH', list(search_state))
-    db_queue.expect('LOGSEARCH', search_state)
-    db_queue.send('OK', None)
-    task.poll(0)
-    db_queue.check()
-
-
 def test_log_valid_project_page_hit(db_queue, log_queue, stats_queue,
                                     project_state, task):
     log_queue.send_msg('LOGPROJECT', list(project_state))
@@ -122,19 +113,16 @@ def test_log_invalid(db_queue, log_queue, stats_queue, task):
 
 
 def test_log_summary(db_queue, log_queue, stats_queue, download_state,
-                     download_metadata_state, search_state, project_state,
+                     download_metadata_state, project_state,
                      json_state, page_state, task):
     log_queue.send_msg('LOGDOWNLOAD', list(download_state))
     log_queue.send_msg('LOGMETADATA', list(download_metadata_state))
-    log_queue.send_msg('LOGSEARCH', list(search_state))
     log_queue.send_msg('LOGPROJECT', list(project_state))
     log_queue.send_msg('LOGJSON', list(json_state))
     log_queue.send_msg('LOGPAGE', list(page_state))
     db_queue.expect('LOGDOWNLOAD', download_state)
     db_queue.send('OK', None)
     db_queue.expect('LOGMETADATA', download_metadata_state)
-    db_queue.send('OK', None)
-    db_queue.expect('LOGSEARCH', search_state)
     db_queue.send('OK', None)
     db_queue.expect('LOGPROJECT', project_state)
     db_queue.send('OK', None)
@@ -148,14 +136,12 @@ def test_log_summary(db_queue, log_queue, stats_queue, download_state,
     task.poll(0)
     task.poll(0)
     task.poll(0)
-    task.poll(0)
     db_queue.check()
     task.log_counters()
     # Index [-2] is python<3.8 for call.args
     assert set(call[-2] for call in task.logger.info.call_args_list) == {
         ('logged %d %s in the last minute', 1, 'downloads'),
         ('logged %d %s in the last minute', 1, 'metadata downloads'),
-        ('logged %d %s in the last minute', 1, 'searches'),
         ('logged %d %s in the last minute', 1, 'project hits'),
         ('logged %d %s in the last minute', 1, 'JSON hits'),
         ('logged %d %s in the last minute', 1, 'page hits'),

--- a/tests/master/test_the_oracle.py
+++ b/tests/master/test_the_oracle.py
@@ -292,16 +292,6 @@ def test_log_download(db, with_files, download_state, db_client):
             "SELECT filename FROM downloads").scalar() == download_state.filename
 
 
-def test_log_search(db, with_files, search_state, db_client):
-    with db.begin():
-        assert db.execute("SELECT COUNT(*) FROM searches").scalar() == 0
-    db_client.log_search(search_state)
-    with db.begin():
-        assert db.execute("SELECT COUNT(*) FROM searches").scalar() == 1
-        assert db.execute(
-            "SELECT package FROM searches").scalar() == search_state.package
-
-
 def test_log_project_page_hit(db, with_files, project_state, db_client):
     with db.begin():
         assert db.execute("SELECT COUNT(*) FROM project_page_hits").scalar() == 0


### PR DESCRIPTION
Drop the `searches` table and `log_search()` function from the database (new 0.25 to 0.26 migration), and remove `LOGSEARCH` handling from the lumberjack, logger, protocols and states. pip hits on package index pages are now ignored rather than logged as searches.