### PR TITLE
Reconnect and retry DB requests on OperationalError instead of crashing

### DIFF
--- a/piwheels/master/db.py
+++ b/piwheels/master/db.py
@@ -133,12 +133,19 @@ class Database:
     engines = {}
 
     def __init__(self, dsn):
+        self._dsn = dsn
+        self._conn = self._connect()
+        self._reflect()
+
+    def _connect(self):
         try:
-            engine = Database.engines[dsn]
+            engine = Database.engines[self._dsn]
         except KeyError:
-            engine = create_engine(dsn)
-            Database.engines[dsn] = engine
-        self._conn = engine.connect()
+            engine = create_engine(self._dsn)
+            Database.engines[self._dsn] = engine
+        return engine.connect()
+
+    def _reflect(self):
         try:
             self._meta = MetaData(bind=self._conn)
             with warnings.catch_warnings():
@@ -169,6 +176,19 @@ class Database:
         except:
             self._conn.close()
             raise
+
+    def reconnect(self):
+        """
+        Re-establishes the database connection after it has been lost (e.g.
+        the server closed it unexpectedly).
+        """
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except Exception:
+                pass
+        self._conn = self._connect()
+        self._reflect()
 
     def close(self):
         if self._conn is not None:

--- a/piwheels/master/the_oracle.py
+++ b/piwheels/master/the_oracle.py
@@ -40,6 +40,8 @@ to it.
 import inspect
 from datetime import timezone
 
+from sqlalchemy.exc import OperationalError
+
 from .. import const, protocols, transport, tasks
 from .db import Database, RewritePendingRow
 
@@ -102,7 +104,16 @@ class TheOracle(tasks.NonStopTask):
             addr, msg, data = b'', '', str(exc)
         try:
             handler, data_to_args = self.handlers[msg]
-            result = handler(*data_to_args(data))
+            try:
+                result = handler(*data_to_args(data))
+            except OperationalError:
+                # The database connection has probably dropped (e.g. the
+                # server closed it unexpectedly); reconnect and retry the
+                # request once before giving up
+                self.logger.warning(
+                    'database connection lost; reconnecting')
+                self.db.reconnect()
+                result = handler(*data_to_args(data))
         except Exception as exc:
             self.logger.error('Error handling db request: %s', msg)
             msg, data = 'ERROR', str(exc)


### PR DESCRIPTION
A dropped Postgres connection (server closed the connection unexpectedly) previously surfaced as an unhandled IOError in whichever task issued the request (lumberjack, the_scribe, big_brother, etc.), which is treated as fatal by Task.run() and sends QUIT, taking down the entire master. TheOracle now catches OperationalError around the handler call, reconnects the Database, and retries the request once before falling back to the existing error-reply path.